### PR TITLE
Fix SYSTEM account detection on localized Windows

### DIFF
--- a/Install-LBFO.ps1
+++ b/Install-LBFO.ps1
@@ -39,9 +39,13 @@ function Ensure-Admin {
 }
 
 function Ensure-System {
-  $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
-  Log "Current security context: $identity" Cyan
-  if ($identity -eq 'NT AUTHORITY\SYSTEM') { return }
+  $id = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+  $identity = $id.Name
+  $sid = $id.User.Value
+
+  Log "Current security context: $identity / SID: $sid" Cyan
+
+  if ($sid -eq 'S-1-5-18') { return }
 
   Ensure-Admin
   $psexec = Join-Path $PSScriptRoot 'PsExec.exe'


### PR DESCRIPTION
This PR fixes SYSTEM account detection on localized Windows installations.

Previously, the script checked for:
`NT AUTHORITY\SYSTEM`

This is language-dependent and fails on non-English Windows (for example, Russian Windows uses `NT AUTHORITY\СИСТЕМА`).

The check has been replaced with SID-based detection using: `S-1-5-18`

This is the well-known SID for Local SYSTEM and works consistently across all Windows locales.
